### PR TITLE
The Impact of Instant Messaging on the Energy Consumption of Android Devices

### DIFF
--- a/_data/papers.yml
+++ b/_data/papers.yml
@@ -1,3 +1,15 @@
+- title: "The Impact of Instant Messaging on the Energy Consumption of Android Devices"
+  authors:
+    - Stylianos Rammos
+    - Mansi Mundra
+    - Guijing Xu
+    - Chuyi Tong
+    - Wojciech Ziółkowski
+    - Ivano Malavolta
+  venue: 8th IEEE/ACM International Conference on Mobile Software Engineering and Systems (MOBILESoft '21)
+  year: 2021
+  doi: 10.1109/MobileSoft52590.2021.00007
+
 - title: "Energy Efficient Adaptation Engines for Android Applications"
   authors:
     - Angel Cañete


### PR DESCRIPTION
*Context.* One of the primary uses of mobile devices is to send and receive instant messages via messaging apps. However, no evidence is still available about how receiving instant messages impacts the energy consumption of mobile devices. 

*Goal.* With this study we aim to empirically assess to what extent the number and distribution of received instant messages impact the energy consumption of Android devices.