### PR TITLE
An Empirical Study on the Energy Consumption of the Google Meet and Zoom Android apps

### DIFF
--- a/_data/papers.yml
+++ b/_data/papers.yml
@@ -1,3 +1,15 @@
+- title: "Do You Have the Energy for This Meeting? An Empirical Study on the Energy Consumption of the Google Meet and Zoom Android apps"
+  authors:
+    - Leonhard Wattenbach
+    - Basel Aslan
+    - Matteo Maria Fiore
+    - Henley Ding
+    - Roberto Verdecchia
+    - Ivano Malavolta
+  venue: 9th IEEE/ACM International Conference on Mobile Software Engineering and Systems (MOBILESoft '22)
+  year: 2022
+  preprint: https://www.ivanomalavolta.com/files/papers/MOBILESoft_2022.pdf
+
 - title: "Energy Efficient Adaptation Engines for Android Applications"
   authors:
     - Angel Cañete


### PR DESCRIPTION
*Context.* With “work from home” policies becoming the norm during the COVID-19 pandemic, videoconferencing apps have soared in popularity, especially on mobile devices. However, mobile devices only have limited energy capacities, and their batteries degrade slightly with each charge/discharge cycle.

*Goal.* With this research we aim at comparing the energy consumption of two Android videoconferencing apps, and studying the impact that different features and settings of these apps have on energy consumption.